### PR TITLE
Add training pipeline, evaluation scripts, tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-# slsm-patch-classification
+# SLSM Patch Classification
+
+This project explores Multiple Instance Learning (MIL) approaches for classifying slide-level samples from patch images.
+
+## Setup
+
+1. Install Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Generate dataset JSON files by running the preprocessing script (edit paths inside `src/preprocessing.py` to point to your data):
+   ```bash
+   python src/preprocessing.py
+   ```
+
+## Training
+
+Train a model using the generated JSON files:
+
+```bash
+python src/train.py --bags path/to/bag_to_patches.json \
+                    --labels path/to/bag_labels.json \
+                    --folds path/to/bag_folds.json \
+                    --fold 0 --model attention --epochs 10
+```
+
+The trained weights are saved to `model.pt` by default.
+
+## Evaluation
+
+Evaluate a trained model on another fold:
+
+```bash
+python src/evaluate.py --bags path/to/bag_to_patches.json \
+                      --labels path/to/bag_labels.json \
+                      --folds path/to/bag_folds.json \
+                      --fold 1 --model attention --weights model.pt
+```
+
+## Testing
+
+Unit tests cover dataset loading and model forward passes. Run them with:
+
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+# Core dependencies
+torch==2.2.0
+torchvision==0.17.0
+pandas
+Pillow
+
+# Development
+pytest

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -1,0 +1,55 @@
+import argparse
+from pathlib import Path
+
+import torch
+from torch.utils.data import DataLoader
+
+from dataset import MILDataset, mil_transform
+from model_attention import AttentionMIL
+from model_maxpool import MaxPoolMIL
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description="Evaluate MIL model")
+    parser.add_argument("--bags", type=Path, required=True)
+    parser.add_argument("--labels", type=Path, required=True)
+    parser.add_argument("--folds", type=Path, required=True)
+    parser.add_argument("--fold", type=int, default=1, help="Fold id to evaluate")
+    parser.add_argument("--model", choices=["attention", "maxpool"], default="attention")
+    parser.add_argument("--weights", type=Path, required=True, help="Path to trained weights")
+    return parser.parse_args()
+
+
+def main():
+    args = get_args()
+
+    dataset = MILDataset(
+        args.bags,
+        args.labels,
+        args.folds,
+        [args.fold],
+        transform=mil_transform,
+    )
+    loader = DataLoader(dataset, batch_size=1)
+
+    if args.model == "attention":
+        model = AttentionMIL(pretrained=False)
+    else:
+        model = MaxPoolMIL(pretrained=False)
+    model.load_state_dict(torch.load(args.weights, map_location="cpu"))
+    model.eval()
+
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for bags, labels, _ in loader:
+            outputs, *_ = model(bags)
+            preds = (outputs > 0.5).float()
+            correct += (preds == labels).sum().item()
+            total += labels.numel()
+    acc = correct / total if total else 0
+    print(f"Accuracy: {acc*100:.2f}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/train.py
+++ b/src/train.py
@@ -1,0 +1,61 @@
+import argparse
+from pathlib import Path
+
+import torch
+from torch.utils.data import DataLoader
+
+from dataset import MILDataset, mil_transform
+from model_attention import AttentionMIL
+from model_maxpool import MaxPoolMIL
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description="Train MIL model")
+    parser.add_argument("--bags", type=Path, required=True, help="Path to bag_to_patches.json")
+    parser.add_argument("--labels", type=Path, required=True, help="Path to bag_labels.json")
+    parser.add_argument("--folds", type=Path, required=True, help="Path to bag_folds.json")
+    parser.add_argument("--fold", type=int, default=0, help="Fold id to use for training")
+    parser.add_argument("--model", choices=["attention", "maxpool"], default="attention")
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--output", type=Path, default=Path("model.pt"))
+    return parser.parse_args()
+
+
+def main():
+    args = get_args()
+
+    dataset = MILDataset(
+        args.bags,
+        args.labels,
+        args.folds,
+        [args.fold],
+        transform=mil_transform,
+    )
+    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True)
+
+    if args.model == "attention":
+        model = AttentionMIL(pretrained=False)
+    else:
+        model = MaxPoolMIL(pretrained=False)
+    model.train()
+
+    criterion = torch.nn.BCELoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+
+    for epoch in range(args.epochs):
+        for bags, labels, _ in loader:
+            outputs, *_ = model(bags)
+            loss = criterion(outputs, labels)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+        print(f"Epoch {epoch+1}: loss={loss.item():.4f}")
+
+    torch.save(model.state_dict(), args.output)
+    print(f"Saved model to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import json
+import tempfile
+
+from PIL import Image
+import torch
+
+from src.dataset import MILDataset, mil_transform
+
+
+def create_dummy_data(tmpdir: Path):
+    patch_dir = tmpdir / "patches"
+    patch_dir.mkdir()
+    bag_to_patches = {"bag1": []}
+    bag_labels = {"bag1": 1}
+    bag_folds = {"bag1": 0}
+    for i in range(2):
+        img_path = patch_dir / f"img_{i}.png"
+        Image.new("RGB", (224, 224)).save(img_path)
+        bag_to_patches["bag1"].append(str(img_path))
+    bags = tmpdir / "bags.json"
+    labels = tmpdir / "labels.json"
+    folds = tmpdir / "folds.json"
+    bags.write_text(json.dumps(bag_to_patches))
+    labels.write_text(json.dumps(bag_labels))
+    folds.write_text(json.dumps(bag_folds))
+    return bags, labels, folds
+
+
+def test_dataset_load():
+    with tempfile.TemporaryDirectory() as tmp:
+        bags, labels, folds = create_dummy_data(Path(tmp))
+        ds = MILDataset(bags, labels, folds, [0], transform=mil_transform)
+        assert len(ds) == 1
+        bag, label, bag_id = ds[0]
+        assert bag.shape[0] == 2  # two patches
+        assert label.item() == 1
+        assert bag_id == "bag1"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+import json
+import tempfile
+
+from PIL import Image
+import torch
+
+from src.dataset import MILDataset, mil_transform
+from src.model_attention import AttentionMIL
+from src.model_maxpool import MaxPoolMIL
+
+
+def create_dummy_dataset(tmpdir: Path):
+    patch_dir = tmpdir / "patches"
+    patch_dir.mkdir()
+    bag_to_patches = {"bag1": []}
+    bag_labels = {"bag1": 0}
+    bag_folds = {"bag1": 0}
+    for i in range(3):
+        img_path = patch_dir / f"img_{i}.png"
+        Image.new("RGB", (224, 224)).save(img_path)
+        bag_to_patches["bag1"].append(str(img_path))
+    bags = tmpdir / "bags.json"
+    labels = tmpdir / "labels.json"
+    folds = tmpdir / "folds.json"
+    bags.write_text(json.dumps(bag_to_patches))
+    labels.write_text(json.dumps(bag_labels))
+    folds.write_text(json.dumps(bag_folds))
+    ds = MILDataset(bags, labels, folds, [0], transform=mil_transform)
+    bag, label, _ = ds[0]
+    return bag.unsqueeze(0), label.unsqueeze(0)
+
+
+def test_model_forward_attention():
+    with tempfile.TemporaryDirectory() as tmp:
+        bag, label = create_dummy_dataset(Path(tmp))
+        model = AttentionMIL(pretrained=False)
+        out, attn = model(bag)
+        assert out.shape == label.shape
+        assert attn.shape[0] == 1
+
+
+def test_model_forward_maxpool():
+    with tempfile.TemporaryDirectory() as tmp:
+        bag, label = create_dummy_dataset(Path(tmp))
+        model = MaxPoolMIL(pretrained=False)
+        out = model(bag)
+        assert out.shape == label.shape


### PR DESCRIPTION
## Summary
- add instructions to README
- specify requirements for the project
- create training and evaluation utilities
- add simple unit tests for dataset and models

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68476b551948832d9ec501d249a3b62e