### PR TITLE
Add AUC plot option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,15 @@ This project explores Multiple Instance Learning (MIL) approaches for classifyin
 
 Train a model using the generated JSON files. The training script automatically
 uses all folds except the one specified by `--fold` for validation.
-Loss curves can optionally be saved with `--plot-loss`.
+Loss curves can optionally be saved with `--plot-loss` and AUC curves with
+`--plot-auc`.
 
 ```bash
 python src/train.py --bags path/to/bag_to_patches.json \
                     --labels path/to/bag_labels.json \
                     --folds path/to/bag_folds.json \
                     --fold 0 --model attention --epochs 10 \
-                    --plot-loss loss.png --device cuda
+                    --plot-loss loss.png --plot-auc auc.png --device cuda
 ```
 
 The trained weights are saved to `model.pt` by default.

--- a/src/train.py
+++ b/src/train.py
@@ -24,6 +24,7 @@ def get_args():
     parser.add_argument("--weight-decay", type=float, default=1e-4)
     parser.add_argument("--dropout", type=float, default=0.5)
     parser.add_argument("--plot-loss", type=Path, help="Optional path to save loss curve plot")
+    parser.add_argument("--plot-auc", type=Path, help="Optional path to save AUC curve plot")
     parser.add_argument("--output", type=Path, default=Path("model.pt"))
     parser.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu",
                         help="Device to train on")
@@ -162,6 +163,17 @@ def main():
         plt.tight_layout()
         plt.savefig(args.plot_loss)
         print(f"Saved loss plot to {args.plot_loss}")
+
+    if args.plot_auc:
+        plt.figure()
+        plt.plot(train_aucs, label="train")
+        plt.plot(val_aucs, label="val")
+        plt.xlabel("Epoch")
+        plt.ylabel("AUC")
+        plt.legend()
+        plt.tight_layout()
+        plt.savefig(args.plot_auc)
+        print(f"Saved AUC plot to {args.plot_auc}")
 
     torch.save(model.state_dict(), args.output)
     print(f"Saved model to {args.output}")


### PR DESCRIPTION
## Summary
- plot AUC curves over the epochs in `train.py`
- document the new `--plot-auc` option

## Testing
- `pytest -q` *(fails: test_model_forward_attention assertion)*

------
https://chatgpt.com/codex/tasks/task_e_684b63c97b80832d94c1bb1256738764