### PR TITLE
Add ROC curve plots for cross-validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ This project explores Multiple Instance Learning (MIL) approaches for classifyin
 Train a model using the provided annotation and fold assignment files. The
 training script trains on the fold specified by `--fold`. Use `--crossval` to
 run all five folds sequentially.
-Loss curves can optionally be saved with `--plot-loss` and AUC curves with
-`--plot-auc`.
+Loss curves can optionally be saved with `--plot-loss`, AUC curves with
+`--plot-auc`, and ROC curves with `--plot-roc`. ROC plots include a dashed
+diagonal reference line and display the AUC value on the plot. When running
+five-fold cross validation with `--crossval` and `--plot-roc`, an additional
+plot will show all fold ROC curves along with the mean curve and AUC.
 
 ```bash
 python src/train.py (associated arguments)

--- a/src/train.py
+++ b/src/train.py
@@ -27,6 +27,7 @@ def get_args():
     parser.add_argument("--plot-loss", type=Path, help="Optional path to save loss curve plot")
     parser.add_argument("--plot-auc", type=Path, help="Optional path to save AUC curve plot")
     parser.add_argument("--plot-acc", type=Path, help="Optional path to save accuracy curve plot")
+    parser.add_argument("--plot-roc", type=Path, help="Optional path to save ROC curve plot")
     parser.add_argument("--output", type=Path, default=Path("model.pt"))
     parser.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu",
                         help="Device to train on")
@@ -66,7 +67,7 @@ def main():
         criterion = torch.nn.CrossEntropyLoss()
         optimizer = torch.optim.Adam(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
 
-        from sklearn.metrics import roc_auc_score
+        from sklearn.metrics import roc_auc_score, roc_curve
         import matplotlib.pyplot as plt
 
         print(f"Training {fold_key} on {device} for {args.epochs} epochs")
@@ -184,14 +185,63 @@ def main():
             plt.savefig(acc_path)
             print(f"Saved accuracy plot to {acc_path}")
 
+        from sklearn.metrics import roc_curve
+
+        fpr, tpr, _ = roc_curve(val_labels, val_preds)
+
+        if args.plot_roc:
+            plt.figure()
+            plt.plot(fpr, tpr, label="ROC")
+            plt.plot([0, 1], [0, 1], linestyle="--", color="gray")
+            plt.xlabel("False Positive Rate")
+            plt.ylabel("True Positive Rate")
+            plt.title(f"ROC Curve {fold_key}")
+            plt.text(0.95, 0.05, f"AUC={val_auc:.3f}", ha="right", va="bottom", transform=plt.gca().transAxes)
+            plt.tight_layout()
+            roc_path = args.plot_roc.with_name(args.plot_roc.stem + f"_{fold_key}" + args.plot_roc.suffix)
+            plt.savefig(roc_path)
+            plt.close()
+            print(f"Saved ROC curve to {roc_path}")
+
         model_path = args.output.with_name(args.output.stem + f"_{fold_key}" + args.output.suffix)
         torch.save(model.state_dict(), model_path)
         print(f"Saved model to {model_path}")
-        return train_accs[-1], val_accs[-1]
+        return train_accs[-1], val_accs[-1], fpr, tpr, val_auc
 
     if args.crossval:
+        roc_data = []
         for key in sorted(fold_assignments.keys()):
-            run_training(key)
+            _, _, fpr, tpr, auc_val = run_training(key)
+            roc_data.append((key, fpr, tpr, auc_val))
+
+        if args.plot_roc and roc_data:
+            import numpy as np
+            import matplotlib.pyplot as plt
+
+            mean_fpr = np.linspace(0.0, 1.0, 100)
+            tprs = []
+            aucs = []
+            for fold_key, fpr, tpr, auc_val in roc_data:
+                plt.plot(fpr, tpr, label=f"{fold_key} (AUC={auc_val:.3f})")
+                interp_tpr = np.interp(mean_fpr, fpr, tpr)
+                interp_tpr[0] = 0.0
+                tprs.append(interp_tpr)
+                aucs.append(auc_val)
+
+            mean_tpr = np.mean(tprs, axis=0)
+            mean_tpr[-1] = 1.0
+            mean_auc = np.mean(aucs)
+            plt.plot(mean_fpr, mean_tpr, color="black", linestyle="--", label=f"Mean (AUC={mean_auc:.3f})")
+            plt.plot([0, 1], [0, 1], linestyle="--", color="gray")
+            plt.xlabel("False Positive Rate")
+            plt.ylabel("True Positive Rate")
+            plt.legend(loc="lower right")
+            plt.text(0.95, 0.05, f"Mean AUC={mean_auc:.3f}", ha="right", va="bottom", transform=plt.gca().transAxes)
+            plt.tight_layout()
+            all_path = args.plot_roc.with_name(args.plot_roc.stem + "_all" + args.plot_roc.suffix)
+            plt.savefig(all_path)
+            plt.close()
+            print(f"Saved cross-validation ROC curve to {all_path}")
     else:
         run_training(f"fold{args.fold}")
 


### PR DESCRIPTION
## Summary
- add `--plot-roc` option to `train.py`
- plot ROC curves for each fold with AUC annotation
- generate combined ROC curve when running cross validation
- document the `--plot-roc` flag in the README
- display AUC values on ROC plots and show mean AUC in combined plot

## Testing
- `python -m py_compile src/train.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862e863b730832d87d40dc0ffc8bd34