### PR TITLE
Fix cross-validation ROC plotting

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -218,6 +218,8 @@ def main():
             import numpy as np
             import matplotlib.pyplot as plt
 
+            plt.figure()
+
             mean_fpr = np.linspace(0.0, 1.0, 100)
             tprs = []
             aucs = []


### PR DESCRIPTION
## Summary
- ensure cross-validation ROC plot starts from a clean figure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862fa9c3690832da44da611c19c005c